### PR TITLE
Fix bug in ifconfig parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Hostname:ubuntu
 If you do not see this, then you need to edit the file `/sbin/net-statistics` to adjust the name of the network interface. Use `ifconfig` to find out the name. This is how I changed the file on my system:
 
 ```bash
-sudo gedit /sbin/net-statistics
+sudo vim /sbin/net-statistics
 ```
 
 Before:
@@ -109,7 +109,7 @@ need to edit your `/etc/network/interfaces` file, because the perl script
 parses the values from this file.
 
 ```bash
-sudo gedit /etc/network/interfaces
+sudo vim /etc/network/interfaces
 ```
 
 Because I use a static IP, I added the following lines:
@@ -118,7 +118,7 @@ Because I use a static IP, I added the following lines:
 # The primary network interface
 auto enp0s3
 iface enp0s3 inet static
-address 192.168.190.134
+address 10.0.2.15
 netmask 255.255.255.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The intention of this repository is to describe the installation of different
 URSim versions on different Ubuntu versions. Currently this document
-describes how to have **URSim 5.10** running in **Ubuntu 18.04.** The VM hat comes
+describes how to have **URSim 5.10** running in **Ubuntu 18.04.** The VM that comes
 from Universal Robots is an 32-bit Lubuntu 14.04.
 
 If you have futher additions or an installation guide for a newer Ubuntu version,
@@ -10,7 +10,7 @@ feel free to create a pull request.
 
 ## Install Ubuntu 18.04
 
-Download and install Ubuntu 18.04 from to [Ubuntu 18.04 releases page](https://releases.ubuntu.com/18.04/). T
+Download and install Ubuntu 18.04 from to [Ubuntu 18.04 releases page](https://releases.ubuntu.com/18.04/).
 
 
 ## Download and unpack URSim 5.10
@@ -26,6 +26,8 @@ The scipt needs Java 6-8 installed, but automatically installs Java 11. If Java 
 ## Run URSim Install Script
 
 Using your bash prompt run the `install.sh` script using the following command.
+
+**Note: If you have ROS installed, running the following script will wipe your install.**
 
 ```bash
 sudo ./install.sh

--- a/README.md
+++ b/README.md
@@ -1,154 +1,60 @@
-# URsim 5.10 Installation Guide for Ubuntu 16.04
+# URsim 5.10 Installation Guide for Ubuntu 18.04
 
 The intention of this repository is to describe the installation of different
 URSim versions on different Ubuntu versions. Currently this document
-describes how to have **URSim 5.10** running in **Ubuntu 16.04.** The VM hat comes
+describes how to have **URSim 5.10** running in **Ubuntu 18.04.** The VM hat comes
 from Universal Robots is an 32-bit Lubuntu 14.04.
 
 If you have futher additions or an installation guide for a newer Ubuntu version,
 feel free to create a pull request.
 
-## Install Ubuntu 16.04
+## Install Ubuntu 18.04
 
-Download and install Ubuntu 16.04 from to [Ubuntu 16.04 releases page](https://releases.ubuntu.com/16.04/). The installation should work on the 32-bit and
-64-bit version. 
+Download and install Ubuntu 18.04 from to [Ubuntu 18.04 releases page](https://releases.ubuntu.com/18.04/). T
 
-To match the linux settings of the Lubuntu VM from Universal Robots, you should
-use the following account settings:
-
-- Hostname: **ursim**
-- Username: **ur**
-- Password: **easybot**
-
-This guide was made with the settings above, so any changes there might cause
-additional trouble.
 
 ## Download and unpack URSim 5.10
 
-Download the URSim 5.10 packacge from the [Universal Robots Download Page](https://www.universal-robots.com/download). You need a user account for this download.
+Download the URSim 5.10 packacge from the [Universal Robots Download Page](https://www.universal-robots.com/download/software-e-series/simulator-linux/offline-simulator-e-series-ur-sim-for-linux-5100/). You need a user account for this download.
 
-Extract the downloaded archive into the `/home/ur/ursim` folder. 
+Extract the downloaded archive as per the instructions.
 
-## Install runit package
+# Dependency requirements
 
-The `install.sh` script will install the `runit` package - this will likely fail on Ubuntu 16.04. The install script already contains a note about this:
-
-```bash
-...
-echo "Installing daemon manager package"
-# if it fails comment out, and check answer https://askubuntu.com/a/665742
-sudo apt-get -y install runit
-...
-```
-
-So before we run the install script, we follow the instructions in the given
-link to install runit: https://askubuntu.com/a/665742. Here are the steps
-summarized:
-
-Install runit: `sudo apt-get install runit`. If this succeeds, you can go to
-the next step and skip the following fix. Most likely you will see the
-folloing error:
-
-```bash
-Setting up runit (2.1.2-3ubuntu1) ...
-start: Unable to connect to Upstart: Failed to connect to socket /com/ubuntu/upstart: Connection refused
-dpkg: error processing package runit (--configure):
- subprocess installed post-installation script returned error exit status 1
-Processing triggers for ureadahead (0.100.0-19) ...
-Errors were encountered while processing:
- runit
-E: Sub-process /usr/bin/dpkg returned an error code (1)
-```
-
-You should find a `runit.postinst` file in `/var/lib/dpkg/info/`. Edit this file
-as root (sudo) in the following way:
-
-Before:
-
-```perl
-if [ -x /sbin/start ]; then #provided by upstart
-  /sbin/start runsvdir
-fi
-```
-
-After:
-
-```perl
-#if [ -x /sbin/start ]; then #provided by upstart
-#  /sbin/start runsvdir
-#fi
-```
-
-When you've saved that change, you can tell apt to finish where it left off and you should be good to go:
-
-```bash
-sudo apt-get install -f
-```
+The scipt needs Java 6-8 installed, but automatically installs Java 11. If Java 8 is installed prior to running the install script it won't install Java 11. Do so by running: `sudo apt install openjdk-8-jdk openjdk-8-jre`
 
 ## Run URSim Install Script
 
-Using your bash prompt run the `/home/ur/ursim/install.sh` using the following command.
+Using your bash prompt run the `install.sh` script using the following command.
 
 ```bash
 sudo ./install.sh
 ```
 
-If runit was installed properly before, the script should run without any errors.
-
-## Copy Libraries to /usr/bin
-
-Since version 5.10 the extracted ursim folder contains the folder `usr/bin` with
-executable files that should be installed to `/usr/bin` but which are not 
-touched by the provided install script. Therfore we need to copy the files manually from
-the usrim folder to `/usr/bin`.
-
-CD into your ursim folder and copy the files:
+## Add binaries to PATH
 
 ```bash
-sudo cp -avr ./usr/bin /usr
+echo -e "\nPATH="$PATH:$HOME/ursim-5.10.0.106288/usr/bin" >> ~/.profile
+source ~/.profile
 ```
 
-Now the command
-
-```bash
-ls /usr/bin/ur*
-```
-
-should output the following:
-
-```bash
-/usr/bin/uradmin
-/usr/bin/uradmin-autorun
-/usr/bin/uradmin-autorun-exec
-/usr/bin/uradmin-control-mode
-/usr/bin/uradmin-firewall-block-ports
-/usr/bin/uradmin-firewall-restrict-incoming
-/usr/bin/uradmin-firewall-service
-/usr/bin/uradmin-help
-/usr/bin/uradmin-passwd-check
-/usr/bin/uradmin-passwd-set
-/usr/bin/uradmin-print
-/usr/bin/uradmin-ssh
-/usr/bin/uradmin-ssh-add-authorized-key
-/usr/bin/uradmin-ssh-remove-authorized-key
-```
 
 ## Provide net-statistics Perl Script
 
 For proper network support ursim requires the perl script `/sbin/net-statistics`.
-I'm not a linux expert and I have no idea where this file comes from so I
-simply copied this file from the URSim Lubuntu 14.04 VM to my Ubuntu 16.04
-installation. I added the file to the repository `src` folder so you can take
-it from there. After you have copied the file, you should make it executable:
+This seems to be a custom script generated for the URSim, but not provided in the installation. The script is located in the src directory of this repository.
+Download the file, move it to the correct location and add executable permisions:
 
 ```bash
-sudo chmod u=rwx,g=rx,o=rx /sbin/net-statistics
+wget https://raw.githubusercontent.com/ljden/URSim_Install_Guides/main/src/net-statistics
+sudo mv net-statistics /sbin/
+sudo chmod +x /sbin/net-statistics
 ```
 
 Now you can test the script
 
 ```bash
-perl /sbin/net-statistics
+net-statistics
 ```
 
 It should print out something like this:
@@ -185,7 +91,7 @@ After:
 ```perl
 #!/usr/bin/perl
 
-my $interface = "ens33";
+my $interface = "enp0s3";
 my $isDhcp = 0;
 my $isStatic = 0;
 ```
@@ -212,8 +118,8 @@ Because I use a static IP, I added the following lines:
 
 ```bash
 # The primary network interface
-auto ens33
-iface ens33 inet static
+auto enp0s3
+iface enp0s3 inet static
 address 192.168.190.134
 netmask 255.255.255.0
 ```
@@ -225,8 +131,8 @@ If you prefer DHCP you can configure the interface like this:
 
 ```bash
 # The primary network interface
-auto ens33
-iface ens33 inet dhcp
+auto enp0s3
+iface enp0s3 inet dhcp
 ```
 
 ## Start URSim

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # URsim 5.10 Installation Guide for Ubuntu 18.04
 
-The intention of this repository is to describe the installation of different
-URSim versions on different Ubuntu versions. Currently this document
-describes how to have **URSim 5.10** running in **Ubuntu 18.04.** The VM that comes
-from Universal Robots is an 32-bit Lubuntu 14.04.
+Currently this document describes how to install **URSim 5.10** in **Ubuntu 18.04.** 
 
-If you have futher additions or an installation guide for a newer Ubuntu version,
-feel free to create a pull request.
+If you have futher additions, feel free to create a pull request.
 
 ## Install Ubuntu 18.04
 

--- a/src/net-statistics
+++ b/src/net-statistics
@@ -49,13 +49,13 @@ if ($isNetDown) {
 
 foreach $line (@ifconfig) {
     chomp $line;
-    if($line =~ /inet addr/) {
+    if($line =~ /inet /) {
 	$addr = $line;
-	$addr =~ s/.*inet addr:([^ ]*).*/$1/;
+	$addr =~ s/.*inet ([^ ]*).*/$1/;
     }
-    if($line =~ /Mask/) {
+    if($line =~ /netmask/) {
 	$mask = $line;
-	$mask =~ s/.*Mask:([^ ]*).*/$1/;
+	$mask =~ s/.*netmask ([^ ]*).*/$1/;
     }
 }
 


### PR DESCRIPTION
Output of ifconfig on ubuntu 18.04. Note `intet addr:` and `Mask:` do not exist. 
```
enp0s3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.0.2.15  netmask 255.255.255.0  broadcast 10.0.2.255
        inet6 fe80::a00:27ff:fe4c:eb1d  prefixlen 64  scopeid 0x20<link>
        ether 08:00:27:4c:eb:1d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 62  bytes 7089 (7.0 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```